### PR TITLE
William test

### DIFF
--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useState } from "react";
-import { UserButton } from "@stackframe/stack";
-import { useUser } from "@stackframe/stack";
+import { UserButton, OAuthButtonGroup, SelectedTeamSwitcher, UserAvatar, useUser } from "@stackframe/stack";
 import { api } from "~/trpc/react";
 import { ThemeToggle } from "~/components/theme-toggle";
 import Link from "next/link";
+import { Moon } from "lucide-react";
 
 export default function TempPage() {
   const [inputText, setInputText] = useState("");
@@ -58,6 +58,52 @@ export default function TempPage() {
                 </p>
               </div>
             )}
+          </section>
+
+          <section className="space-y-4">
+            <h3 className="text-xl font-semibold">Stack Auth Widgets</h3>
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="p-4 border rounded-lg space-y-3">
+                <h4 className="font-semibold">User Button</h4>
+                <p className="text-sm text-muted-foreground">Account menu with sign-in/out and settings.</p>
+                {/* eslint-disable-next-line @typescript-eslint/no-unused-vars */}
+                <UserButton showUserInfo extraItems={[{ text: "Extra Item example", icon: <Moon className="size-4" />, onClick: () => { let x; } }]} />
+              </div>
+              <div className="p-4 border rounded-lg space-y-3">
+                <h4 className="font-semibold">User Avatar</h4>
+                <p className="text-sm text-muted-foreground">Avatar rendered from Stack user profile.</p>
+                <div className="flex items-center gap-3">
+                  <UserAvatar user={user ?? undefined} />
+                  {/* <span className="text-sm text-muted-foreground">{user ? (user.displayName ?? user.primaryEmail) : "Not signed in"}</span> */}
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section className="space-y-4">
+            <h3 className="text-xl font-semibold">OAuth Providers</h3>
+            {user ? (
+              <p className="text-sm text-muted-foreground">You are signed in. Sign-in/sign-up buttons are hidden.</p>
+            ) : (
+              <div className="grid gap-6 md:grid-cols-2">
+                <div className="p-4 border rounded-lg space-y-3">
+                  <h4 className="font-semibold">Sign in</h4>
+                  <OAuthButtonGroup type="sign-in" />
+                </div>
+                <div className="p-4 border rounded-lg space-y-3">
+                  <h4 className="font-semibold">Sign up</h4>
+                  <OAuthButtonGroup type="sign-up" />
+                </div>
+              </div>
+            )}
+          </section>
+
+          <section className="space-y-4">
+            <h3 className="text-xl font-semibold">Teams</h3>
+            <div className="p-4 border rounded-lg space-y-3">
+              <p className="text-sm text-muted-foreground">Switch the currently selected team (if enabled for your project).</p>
+              <SelectedTeamSwitcher allowNull nullLabel="No team" />
+            </div>
           </section>
 
           <section className="space-y-4">

--- a/src/server/api/routers/auth.ts
+++ b/src/server/api/routers/auth.ts
@@ -8,18 +8,22 @@ export const authRouter = createTRPCRouter({
 
     // console.log("user", user);
 
+    if (!user) {
+      return null;
+    }
+
     let dbUser = await db.user.findUnique({
       where: {
-        id: user?.id,
+        id: user.id,
       },
     });
 
     dbUser ??= await db.user.create({
       data: {
-        id: user?.id,
-        name: user?.displayName,
-        email: user?.primaryEmail,
-        image: user?.profileImageUrl,
+        id: user.id,
+        name: user.displayName,
+        email: user.primaryEmail,
+        image: user.profileImageUrl,
       },
     });
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds auth UI widgets (UserButton extras, UserAvatar, OAuth sign-in/up, team switcher) and updates `auth.me` to return `null` when unauthenticated with stricter user field access.
> 
> - **Frontend (src/app/auth/page.tsx)**:
>   - Add Stack auth widgets: `UserButton` with `extraItems`, `UserAvatar`.
>   - Add OAuth provider buttons via `OAuthButtonGroup` for sign-in and sign-up (hidden when signed in).
>   - Add team selection UI with `SelectedTeamSwitcher`.
>   - Import `Moon` icon for menu item.
> - **Backend (src/server/api/routers/auth.ts)**:
>   - Update `auth.me` to return `null` if no `stackServerApp.getUser()`.
>   - Remove optional chaining when creating/finding DB user; access `user.id`, `user.displayName`, `user.primaryEmail`, `user.profileImageUrl` directly.
>   - Comment out debug `console.log`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39437d7dec350e160b653f4a77e64f113117347f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->